### PR TITLE
Update Skia and Enable Shaping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ include = [
 winit = "0.20.0-alpha4"
 raw-window-handle = "0.3"
 ash = "0.29"
-skia-safe = { version = "0.17", features = ["vulkan"] }
+skia-safe = { version = "0.21", features = ["vulkan", "svg", "shaper", "textlayout"] }
 
 log="0.4"
 


### PR DESCRIPTION
This enables shaping and some other skia features. I needed the shaper features in a neovim gui I am working on but since skia-shape downloads binaries I needed to enable all of the optional skia features so that building of the entire skia library wasn't necessary.