### PR TITLE
Update skia-safe and reenable semantic versioning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ complete = ["skia-safe/shaper", "skia-safe/svg", "skia-safe/textlayout"]
 winit = "=0.20.0-alpha6"
 raw-window-handle = "0.3"
 ash = "0.29"
-skia-safe = { version = ">=0.21", features = ["vulkan"] }
+skia-safe = { version = "0.26.1", features = ["vulkan"] }
 
 log="0.4"
 


### PR DESCRIPTION
This PR updates skia-safe and re-adds semantic versioning for it. 

Probably there was a reason why semver was disabled, but with regular breaking changes to Google's Skia library, rust-skia can only do so much in trying to compensate for and prevent breaking the build of downstream Rust dependencies. For example, several functions were removed in the latest milestone update.

Therefore I am suggesting to turn semver back on, specifically now that Skulpin gets used in projects like neovide.
