### PR TITLE
update sdl to v0.3.4 (Patch allow gcc10 )

### DIFF
--- a/skulpin-renderer-sdl2/Cargo.toml
+++ b/skulpin-renderer-sdl2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skulpin-renderer-sdl2"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Philip Degarmo <aclysma@gmail.com>"]
 edition = "2018"
 description = "Support for sdl2 in skulpin"
@@ -17,6 +17,6 @@ categories = ["graphics", "gui", "multimedia", "rendering", "visualization"]
 [dependencies]
 skulpin-renderer = { version = "0.3", path = "../skulpin-renderer" }
 
-sdl2 = { version = ">=0.33" }
+sdl2 = { version = ">=0.34.3" }
 
 log="0.4"


### PR DESCRIPTION
build under gcc10 will result on error:

```bash
 note: /usr/bin/ld: /tmp/rustcSwsrGo/libsdl2_sys-ab14be8f9d7d1911.rlib(SDL_gesture.c.o):(.bss.WAYLAND_wl_proxy_get_user_data+0x0): multiple definition of `WAYLAND_wl_proxy_get_user_data'; /tmp/rustcSwsrGo/libsdl2_sys-ab14be8f9d7d1911.rlib(SDL_events.c.o):(.bss.WAYLAND_wl_proxy_get_user_data+0x0): first defined here
          /usr/bin/ld: /tmp/rustcSwsrGo/libsdl2_sys-ab14be8f9d7d1911.rlib(SDL_gesture.c.o):(.bss.WAYLAND_wl_proxy_set_user_data+0x0): multiple definition of `WAYLAND_wl_proxy_set_user_data'; /tmp/rustcSwsrGo/libsdl2_sys-ab14be8f9d7d1911.rlib(SDL_events.c.o):(.bss.WAYLAND_wl_proxy_set_user_data+0x0): first defined here
          /usr/bin/ld: /tmp/rustcSwsrGo/libsdl2_sys-ab14be8f9d7d1911.rlib(SDL_gesture.c.o):(.bss.WAYLAND_wl_proxy_add_listener+0x0): multiple definition of `WAYLAND_wl_proxy_add_listener'; /tmp/rustcSwsrGo/libsdl2_sys-ab14be8f9d7d1911.rlib(SDL_events.c.o):(.bss.WAYLAND_wl_proxy_add_listener+0x0): first defined here
          /usr/bin/ld: /tmp/rustcSwsrGo/libsdl2_sys-ab14be8f9d7d1911.rlib(SDL_gesture.c.o):(.bss.WAYLAND_wl_proxy_destroy+0x0): multiple definition of `WAYLAND_wl_proxy_destroy'; /tmp/rustcSwsrGo/libsdl2_sys-ab14be8f9d7d1911.rlib(SDL_events.c.o):(.bss.WAYLAND_wl_proxy_destroy+0x0): first defined here
          /usr/bin/ld: /tmp/rustcSwsrGo/libsdl2_sys-ab14be8f9d7d1911.rlib(SDL_gesture.c.o):(.bss.WAYLAND_wl_proxy_marshal_constructor_versioned+0x0): multiple definition of `WAYLAND_wl_proxy_marshal_constructor_versioned'; /tmp/rustcSwsrGo/libsdl2_sys-ab14be8f9d7d1911.rlib(SDL_events.c.o):(.bss.WAYLAND_wl_proxy_marshal_constructor_versioned+0x0): first defined here
          /usr/bin/ld: /tmp/rustcSwsrGo/libsdl2_sys-ab14be8f9d7d1911.rlib(SDL_gesture.c.o):(.bss.WAYLAND_wl_proxy_marshal_constructor+0x0): multiple definition of `WAYLAND_wl_proxy_marshal_constructor'; /tmp/rustcSwsrGo/libsdl2_sys-ab14be8f9d7d1911.rlib(SDL_events.c.o):(.bss.WAYLAND_wl_proxy_marshal_constructor+0x0): first defined here
          /usr/bin/ld: /tmp/rustcSwsrGo/libsdl2_sys-ab14be8f9d7d1911.rlib(SDL_gesture.c.o):(.bss.WAYLAND_wl_proxy_create+0x0): multiple definition of `WAYLAND_wl_proxy_create'; /tmp/rustcSwsrGo/libsdl2_sys-ab14be8f9d7d1911.rlib(SDL_events.c.o):(.bss.WAYLAND_wl_proxy_create+0x0): first defined here
          /usr/bin/ld: /tmp/rustcSwsrGo/libsdl2_sys-ab14be8f9d7d1911.rlib(SDL_gesture.c.o):(.bss.WAYLAND_wl_proxy_marshal+0x0): multiple definition of `WAYLAND_wl_proxy_marshal'; /tmp/rustcSwsrGo/libsdl2_sys-ab14be8f9d7d1911.rlib(SDL_events.c.o):(.bss.WAYLAND_wl_proxy_marshal+0x0): first defined here
          /usr/bin/ld: /tmp/rustcSwsrGo/libsdl2_sys-ab14be8f9d7d1911.rlib(SDL_keyboard.c.o):(.bss.WAYLAND_wl_proxy_get_user_data+0x0): multiple definition of `WAYLAND_wl_proxy_get_user_data'; /tmp/rustcSwsrGo/libsdl2_sys-ab14be8f9d7d1911.rlib(SDL_events.c.o):(.bss.WAYLAND_wl_proxy_get_user_data+0x0): first defined here
          /usr/bin/ld: /tmp/rustcSwsrGo/libsdl2_sys-ab14be8f9d7d1911.rlib(SDL_keyboard.c.o):(.bss.WAYLAND_wl_proxy_set_user_data+0x0): multiple definition of `WAYLAND_wl_proxy_set_user_data'; /tmp/rustcSwsrGo/libsdl2_sys-ab14be8f9d7d1911.rlib(SDL_events.c.o):(.bss.WAYLAND_wl_proxy_set_user_data+0x0): first defined here
          /usr/bin/ld: /tmp/rustcSwsrGo/libsdl2_sys-ab14be8f9d7d1911.rlib(SDL_keyboard.c.o):(.bss.WAYLAND_wl_proxy_add_listener+0x0): multiple definition of `WAYLAND_wl_proxy_add_listener'; /tmp/rustcSwsrGo/libsdl2_sys-ab14be8f9d7d1911.rlib(SDL_events.c.o):(.bss.WAYLAND_wl_proxy_add_listener+0x0): first defined here
          /usr/bin/ld: /tmp/rustcSwsrGo/libsdl2_sys-ab14be8f9d7d1911.rlib(SDL_keyboard.c.o):(.bss.WAYLAND_wl_proxy_destroy
```

this PR resolved the problem: https://github.com/Rust-SDL2/rust-sdl2/pull/1010

related issue:  https://github.com/Kethku/neovide/issues/306