### PR TITLE
Improve validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,16 @@ script:
   - if [ $SKIP_CLIPPY = 0 ]; then cargo clippy -- -D warnings; fi
 matrix:
   include:
-    - name: "Windows MSVC 1.40.0"
-      rust: 1.40.0-msvc
+    - name: "Windows MSVC 1.43.0"
+      rust: 1.43.0-msvc
       os: windows
       env: SKIP_FORMAT_CHECK=1 SKIP_CLIPPY=1
-    - name: "OSX 1.40.0"
-      rust: 1.40.0
+    - name: "OSX 1.43.0"
+      rust: 1.43.0
       os: osx
       env: SKIP_FORMAT_CHECK=1 SKIP_CLIPPY=1
-    - name: "Linux 1.40.0"
-      rust: 1.40.0
+    - name: "Linux 1.43.0"
+      rust: 1.43.0
       os: linux
       env: SKIP_FORMAT_CHECK=1 SKIP_CLIPPY=1
     - name: "Windows MSVC Stable"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.10.0 (Unreleased)
+
+ * Improvements to validation layer handling
+     * Search for VK_LAYER_KHRONOS_validation but fall back to VK_LAYER_LUNARG_standard_validation if it's not present
+     * Return a failure with a better error message if neither exist
+ * Validation is now off by default in the examples
+ * Rust minimum version is now 1.43.0
+ * skia-safe minimum version is now 0.30.1
+
 ## 0.9.5
 
  * Bump macos dependencies (metal/cocoa)

--- a/examples/interactive_sdl2.rs
+++ b/examples/interactive_sdl2.rs
@@ -82,7 +82,7 @@ fn main() {
     let window = Sdl2Window::new(&sdl_window);
 
     let renderer = RendererBuilder::new()
-        .use_vulkan_debug_layer(true)
+        .use_vulkan_debug_layer(false)
         .coordinate_system(skulpin::CoordinateSystem::VisibleRange(
             visible_range,
             scale_to_fit,

--- a/examples/interactive_winit_app.rs
+++ b/examples/interactive_winit_app.rs
@@ -27,7 +27,7 @@ fn main() {
 
     AppBuilder::new()
         .app_name(CString::new("Skulpin Example App").unwrap())
-        .use_vulkan_debug_layer(true)
+        .use_vulkan_debug_layer(false)
         .inner_size(LogicalSize::new(900, 600))
         .run(example_app);
 }

--- a/examples/physics.rs
+++ b/examples/physics.rs
@@ -137,7 +137,7 @@ fn main() {
 
     AppBuilder::new()
         .app_name(CString::new("Skulpin Example App").unwrap())
-        .use_vulkan_debug_layer(true)
+        .use_vulkan_debug_layer(false)
         .inner_size(LogicalSize::new(900, 600))
         .run(example_app);
 }

--- a/examples/sdl2_renderer_only.rs
+++ b/examples/sdl2_renderer_only.rs
@@ -46,7 +46,7 @@ fn main() {
     let window = Sdl2Window::new(&sdl_window);
 
     let renderer = RendererBuilder::new()
-        .use_vulkan_debug_layer(true)
+        .use_vulkan_debug_layer(false)
         .coordinate_system(skulpin::CoordinateSystem::VisibleRange(
             visible_range,
             scale_to_fit,

--- a/examples/skulpin_app.rs
+++ b/examples/skulpin_app.rs
@@ -35,7 +35,7 @@ fn main() {
 
     AppBuilder::new()
         .app_name(CString::new("Skulpin Example App").unwrap())
-        .use_vulkan_debug_layer(true)
+        .use_vulkan_debug_layer(false)
         .inner_size(logical_size)
         .coordinate_system(CoordinateSystem::VisibleRange(visible_range, scale_to_fit))
         .run(example_app);

--- a/examples/winit_imgui.rs
+++ b/examples/winit_imgui.rs
@@ -49,7 +49,7 @@ fn main() {
 
     // Create the renderer, which will draw to the window
     let renderer = skulpin::RendererBuilder::new()
-        .use_vulkan_debug_layer(true)
+        .use_vulkan_debug_layer(false)
         .coordinate_system(skulpin::CoordinateSystem::VisibleRange(
             visible_range,
             scale_to_fit,

--- a/examples/winit_renderer_only.rs
+++ b/examples/winit_renderer_only.rs
@@ -37,7 +37,7 @@ fn main() {
 
     // Create the renderer, which will draw to the window
     let renderer = skulpin::RendererBuilder::new()
-        .use_vulkan_debug_layer(true)
+        .use_vulkan_debug_layer(false)
         .coordinate_system(skulpin::CoordinateSystem::VisibleRange(
             visible_range,
             scale_to_fit,

--- a/skulpin-renderer/Cargo.toml
+++ b/skulpin-renderer/Cargo.toml
@@ -22,7 +22,7 @@ textlayout = ["skia-safe/textlayout"]
 complete = ["skia-safe/textlayout"]
 
 [dependencies]
-ash = ">=0.31"
+ash = ">=0.30"
 skia-safe = { version = ">=0.30.1", features = ["vulkan"] }
 skia-bindings = { version = ">=0.30.1" }
 

--- a/skulpin-renderer/src/instance.rs
+++ b/skulpin-renderer/src/instance.rs
@@ -1,4 +1,4 @@
-use std::ffi::CString;
+use std::ffi::{CString, CStr};
 
 pub use ash::version::{DeviceV1_0, EntryV1_0, InstanceV1_0};
 use ash::vk;
@@ -111,34 +111,56 @@ impl VkInstance {
             .engine_version(0)
             .api_version(api_version);
 
-        // Determine what layers to use
-        let validation_layer_name = CString::new("VK_LAYER_LUNARG_standard_validation").unwrap();
-
         let mut layer_names = vec![];
-        if !validation_layer_debug_report_flags.is_empty() {
-            //TODO: Validate that the layer exists
-            //if layers.iter().find(|x| CStr::from_bytes_with_nul(&x.layer_name) == &validation_layer_name) {
-            layer_names.push(validation_layer_name);
-            //}
-        }
-
-        let layers_names_raw: Vec<*const i8> = layer_names
-            .iter()
-            .map(|raw_name| raw_name.as_ptr())
-            .collect();
-
-        // Determine what extensions to use
-        let mut extension_names_raw = window.extension_names();
+        let mut extension_names = window.extension_names();
 
         if !validation_layer_debug_report_flags.is_empty() {
-            extension_names_raw.push(DebugReport::name().as_ptr())
+            // Find the best validation layer that's available
+            let best_validation_layer = VkInstance::find_best_validation_layer(&layers);
+            if best_validation_layer.is_none() {
+                log::error!("Could not find an appropriate validation layer. Check that the vulkan SDK has been installed or disable validation.");
+                return Err(vk::Result::ERROR_LAYER_NOT_PRESENT.into());
+            }
+
+            let debug_extension = DebugReport::name();
+            let has_debug_extension = extensions
+                .iter()
+                .find(|extension| unsafe {
+                    debug_extension == CStr::from_ptr(extension.extension_name.as_ptr())
+                })
+                .is_some();
+
+            if !has_debug_extension {
+                log::error!("Could not find the debug extension. Check that the vulkan SDK has been installed or disable validation.");
+                return Err(vk::Result::ERROR_EXTENSION_NOT_PRESENT.into());
+            }
+
+            if let Some(best_validation_layer) = best_validation_layer {
+                if has_debug_extension {
+                    layer_names.push(best_validation_layer.as_ptr());
+                    extension_names.push(DebugReport::name().as_ptr());
+                }
+            }
+        };
+
+        if log_enabled!(log::Level::Debug) {
+            let layer_names_as_cstr: Vec<_> = layer_names
+                .iter()
+                .map(|ptr| unsafe { CStr::from_ptr(*ptr) })
+                .collect();
+            log::debug!("Using layers: {:?}", layer_names_as_cstr);
+            let extension_names_as_cstr: Vec<_> = extension_names
+                .iter()
+                .map(|ptr| unsafe { CStr::from_ptr(*ptr) })
+                .collect();
+            log::debug!("Using extensions: {:?}", extension_names_as_cstr);
         }
 
         // Create the instance
         let create_info = vk::InstanceCreateInfo::builder()
             .application_info(&appinfo)
-            .enabled_layer_names(&layers_names_raw)
-            .enabled_extension_names(&extension_names_raw);
+            .enabled_layer_names(&layer_names)
+            .enabled_extension_names(&extension_names);
 
         info!("Creating vulkan instance");
         let instance: ash::Instance = unsafe { entry.create_instance(&create_info, None)? };
@@ -159,6 +181,38 @@ impl VkInstance {
             instance,
             debug_reporter,
         })
+    }
+
+    fn find_best_validation_layer(layers: &Vec<ash::vk::LayerProperties>) -> Option<&'static CStr> {
+        fn khronos_validation_layer_name() -> &'static CStr {
+            CStr::from_bytes_with_nul(b"VK_LAYER_KHRONOS_validation\0")
+                .expect("Wrong extension string")
+        }
+
+        fn lunarg_validation_layer_name() -> &'static CStr {
+            CStr::from_bytes_with_nul(b"VK_LAYER_LUNARG_standard_validation\0")
+                .expect("Wrong extension string")
+        }
+
+        let khronos_validation_layer_name = khronos_validation_layer_name();
+        let lunarg_validation_layer_name = lunarg_validation_layer_name();
+
+        // Find the best validation layer that's available
+        let mut best_available_layer = None;
+        for layer in layers {
+            let layer_name = unsafe { CStr::from_ptr(layer.layer_name.as_ptr()) };
+
+            if layer_name == khronos_validation_layer_name {
+                best_available_layer = Some(khronos_validation_layer_name);
+                break;
+            }
+
+            if layer_name == lunarg_validation_layer_name {
+                best_available_layer = Some(lunarg_validation_layer_name);
+            }
+        }
+
+        best_available_layer
     }
 
     /// This is used to setup a debug callback for logging validation errors

--- a/skulpin-renderer/src/instance.rs
+++ b/skulpin-renderer/src/instance.rs
@@ -123,12 +123,9 @@ impl VkInstance {
             }
 
             let debug_extension = DebugReport::name();
-            let has_debug_extension = extensions
-                .iter()
-                .find(|extension| unsafe {
-                    debug_extension == CStr::from_ptr(extension.extension_name.as_ptr())
-                })
-                .is_some();
+            let has_debug_extension = extensions.iter().any(|extension| unsafe {
+                debug_extension == CStr::from_ptr(extension.extension_name.as_ptr())
+            });
 
             if !has_debug_extension {
                 log::error!("Could not find the debug extension. Check that the vulkan SDK has been installed or disable validation.");
@@ -183,7 +180,7 @@ impl VkInstance {
         })
     }
 
-    fn find_best_validation_layer(layers: &Vec<ash::vk::LayerProperties>) -> Option<&'static CStr> {
+    fn find_best_validation_layer(layers: &[ash::vk::LayerProperties]) -> Option<&'static CStr> {
         fn khronos_validation_layer_name() -> &'static CStr {
             CStr::from_bytes_with_nul(b"VK_LAYER_KHRONOS_validation\0")
                 .expect("Wrong extension string")


### PR DESCRIPTION
 * Improvements to validation layer handling
     * Search for VK_LAYER_KHRONOS_validation but fall back to VK_LAYER_LUNARG_standard_validation if it's not present
     * Return a failure with a better error message if neither exist
 * Validation is now off by default in the examples
 * Rust minimum version is now 1.43.0
