### PR TITLE
Use feature flags to support multiple winit versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,12 +34,12 @@ jobs:
 
       # The normal build with all features
       - name: Build
-        run: cargo check default
+        run: cargo check
         env:
           CARGO_INCREMENTAL: 0
           RUSTFLAGS: "-C debuginfo=0 -D warnings"
 
-
+      # Verify winit 0.21 build works
       - name: Build winit 0.21
         run: cargo check --no-default-features --features=winit-21,skulpin_winit
         if: ${{ runner.os == 'Linux' }}
@@ -47,6 +47,7 @@ jobs:
           CARGO_INCREMENTAL: 0
           RUSTFLAGS: "-C debuginfo=0 -D warnings"
 
+      # Verify winit 0.23 build works
       - name: Build winit 0.23
         run: cargo check --no-default-features --features=winit-23,skulpin_winit
         if: ${{ runner.os == 'Linux' }}
@@ -54,6 +55,7 @@ jobs:
           CARGO_INCREMENTAL: 0
           RUSTFLAGS: "-C debuginfo=0 -D warnings"
 
+      # Run tests
       - name: Run tests
         run: cargo test --workspace
         if: ${{ runner.os == 'Linux' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 name: CI
 
-on:
-  push:
-    branches: [master]
-  pull_request:
-    branches: [master]
+on: [push, pull_request]
 
 env:
   CARGO_TERM_COLOR: always
@@ -36,8 +32,24 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-check-test-${{ matrix.toolchain }}-${{ hashFiles('**/Cargo.lock') }}
 
+      # The normal build with all features
       - name: Build
-        run: cargo check
+        run: cargo check default
+        env:
+          CARGO_INCREMENTAL: 0
+          RUSTFLAGS: "-C debuginfo=0 -D warnings"
+
+
+      - name: Build winit 0.21
+        run: cargo check --no-default-features --features=winit-21,skulpin_winit
+        if: ${{ runner.os == 'Linux' }}
+        env:
+          CARGO_INCREMENTAL: 0
+          RUSTFLAGS: "-C debuginfo=0 -D warnings"
+
+      - name: Build winit 0.23
+        run: cargo check --no-default-features --features=winit-23,skulpin_winit
+        if: ${{ runner.os == 'Linux' }}
         env:
           CARGO_INCREMENTAL: 0
           RUSTFLAGS: "-C debuginfo=0 -D warnings"
@@ -67,6 +79,5 @@ jobs:
         run: >
           cargo clippy
           --all-targets
-          --all-features
           --
           -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
    from the winit integration.
  * The imgui plugin has been updated to use open-ended versioning. This is published as skulpin-plugin-imgui 0.6.0 but
    does not affect the skulpin release itself as this is a dev-dependency.
+ * Added feature flags winit-21, winit-22, winit-23, and winit-latest for easier control of what winit version to pull
+   in. This also allows us to have version-specific code (for example to handle upstream changes in winit API)
 
 ## 0.10.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,12 @@ skia_complete = ["skulpin-renderer/complete"]
 skulpin_winit = ["skulpin-renderer-winit", "skulpin-app-winit"]
 skulpin_sdl2 = ["skulpin-renderer-sdl2"]
 
-default = ["skulpin_winit", "skulpin_sdl2", "skia_complete"]
+winit-21 = ["skulpin-renderer-winit/winit-21", "skulpin-app-winit/winit-21"]
+winit-22 = ["skulpin-renderer-winit/winit-22", "skulpin-app-winit/winit-22"]
+winit-23 = ["skulpin-renderer-winit/winit-23", "skulpin-app-winit/winit-23"]
+winit-latest = ["skulpin-renderer-winit/winit-latest", "skulpin-app-winit/winit-latest"]
+
+default = ["skulpin_winit", "skulpin_sdl2", "skia_complete", "winit-22"]
 
 [dependencies]
 skulpin-renderer = { version = "0.4", path = "skulpin-renderer" }

--- a/README.md
+++ b/README.md
@@ -92,6 +92,17 @@ features (default behavior), or disable all features. (use `default-features = f
 * `skulpin_sdl2` - Re-export sdl2-related types from the skulpin crate
 * `skulpin_winit` - Re-export winit-related types from the skulpin crate
 
+### Winit versions:
+By default, skulpin uses winit 0.22. If you want to override this, use the appropriate winit feature flag. You will
+need to disable default features (i.e. --no-default-features/default-features = false) so that the default winit-22
+feature does not get included.
+* `winit-21`
+* `winit-22`
+* `winit-23`
+* `winit-latest`
+
+(These feature names match the imgui-rs crate.)
+
 ### Examples of Feature Flag Usage
 
 ```

--- a/skulpin-app-winit/Cargo.toml
+++ b/skulpin-app-winit/Cargo.toml
@@ -17,3 +17,9 @@ skulpin-renderer = { version = "0.4", path = "../skulpin-renderer" }
 skulpin-renderer-winit = { version = "0.4", path = "../skulpin-renderer-winit" }
 
 log="0.4"
+
+[features]
+winit-21 = []
+winit-22 = []
+winit-23 = []
+winit-latest = []

--- a/skulpin-app-winit/src/input_state.rs
+++ b/skulpin-app-winit/src/input_state.rs
@@ -525,10 +525,19 @@ impl InputState {
             }
         } else if let MouseScrollDelta::PixelDelta(d1) = self.mouse_wheel_delta {
             if let MouseScrollDelta::PixelDelta(d2) = delta {
-                self.mouse_wheel_delta = MouseScrollDelta::PixelDelta(LogicalPosition::<f64>::new(
-                    d1.x + d2.x,
-                    d1.y + d2.y,
-                ));
+                #[cfg(any(feature = "winit-21", feature = "winit-22"))]
+                {
+                    self.mouse_wheel_delta = MouseScrollDelta::PixelDelta(
+                        LogicalPosition::<f64>::new(d1.x + d2.x, d1.y + d2.y),
+                    );
+                }
+
+                #[cfg(any(feature = "winit-23", feature = "winit-latest"))]
+                {
+                    self.mouse_wheel_delta = MouseScrollDelta::PixelDelta(
+                        PhysicalPosition::<f64>::new(d1.x + d2.x, d1.y + d2.y),
+                    );
+                }
             } else {
                 self.mouse_wheel_delta = delta;
             }

--- a/skulpin-renderer-winit/Cargo.toml
+++ b/skulpin-renderer-winit/Cargo.toml
@@ -12,7 +12,10 @@ categories = ["graphics", "gui", "multimedia", "rendering", "visualization"]
 
 [dependencies]
 skulpin-renderer = { version = "0.4", path = "../skulpin-renderer" }
-winit = ">=0.21"
+winit-21 = { package = "winit", version = "0.21", optional = true }
+winit-22 = { package = "winit", version = "0.22", optional = true }
+winit-23 = { package = "winit", version = "0.23", optional = true }
+winit-latest = { package = "winit", version = ">=0.23", optional = true }
 ash-window = "0.5.0"
 raw-window-handle = "0.3"
 log="0.4"

--- a/skulpin-renderer-winit/src/lib.rs
+++ b/skulpin-renderer-winit/src/lib.rs
@@ -1,4 +1,12 @@
-pub use winit;
+#[cfg(feature = "winit-21")]
+pub use winit_21 as winit;
+#[cfg(feature = "winit-22")]
+pub use winit_22 as winit;
+#[cfg(feature = "winit-23")]
+pub use winit_23 as winit;
+#[cfg(feature = "winit-latest")]
+pub use winit_latest as winit;
+
 use skulpin_renderer::ash;
 
 pub use ash::version::{DeviceV1_0, EntryV1_0, InstanceV1_0};


### PR DESCRIPTION
This will hopefully solve a couple issues:
 * Defaults to a specific version of winit so that upstream API changes won't break this crate compiling
 * Still allows end-user to opt-in to using more recent versions of winit without having to fork (might not compile, depends on how much winit changes)
