### PR TITLE
Updates for skia-safe >= v0.73.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
     strategy:
       matrix:
         toolchain: [stable, beta]
-        os: [windows-2019, ubuntu-20.04, macos-10.15]
+        os: [windows-2019, ubuntu-20.04, macos-latest]
         exclude:
-          - os: macos-10.15
+          - os: macos-latest
             toolchain: beta
           - os: windows-2019
             toolchain: beta

--- a/examples/hello_skulpin_sdl2.rs
+++ b/examples/hello_skulpin_sdl2.rs
@@ -121,7 +121,7 @@ fn main() {
 
 /// Called when winit passes us a WindowEvent::RedrawRequested
 fn draw(
-    canvas: &mut skia_safe::Canvas,
+    canvas: &skia_safe::Canvas,
     _coordinate_system_helper: &CoordinateSystemHelper,
     frame_count: i32,
 ) {

--- a/examples/hello_skulpin_winit.rs
+++ b/examples/hello_skulpin_winit.rs
@@ -128,7 +128,7 @@ fn main() {
 
 /// Called when winit passes us a WindowEvent::RedrawRequested
 fn draw(
-    canvas: &mut skia_safe::Canvas,
+    canvas: &skia_safe::Canvas,
     _coordinate_system_helper: CoordinateSystemHelper,
     frame_count: i32,
 ) {

--- a/examples/interactive_sdl2.rs
+++ b/examples/interactive_sdl2.rs
@@ -201,7 +201,7 @@ fn update(app_state: &mut ExampleAppState) {
 
 fn draw(
     app_state: &ExampleAppState,
-    canvas: &mut skia_safe::Canvas,
+    canvas: &skia_safe::Canvas,
     _coordinate_system_helper: &CoordinateSystemHelper,
     _window: &dyn HasRawWindowHandle,
 ) {

--- a/skulpin-app-winit/src/app.rs
+++ b/skulpin-app-winit/src/app.rs
@@ -67,7 +67,7 @@ pub struct AppDrawArgs<'a, 'b, 'c, 'd> {
     pub app_control: &'a AppControl,
     pub input_state: &'b InputState,
     pub time_state: &'c TimeState,
-    pub canvas: &'d mut skia_safe::Canvas,
+    pub canvas: &'d skia_safe::Canvas,
     pub coordinate_system_helper: CoordinateSystemHelper,
 }
 

--- a/skulpin-renderer/Cargo.toml
+++ b/skulpin-renderer/Cargo.toml
@@ -27,7 +27,7 @@ rafx = { version = "=0.0.14", features = ["rafx-vulkan", "framework"] }
 bincode = "1.3.1"
 lazy_static = "1"
 
-skia-safe = { version = "0.57.0", features = ["vulkan"] }
-skia-bindings = { version = "0.57.0" }
+skia-safe = { version = ">=0.73.0", features = ["vulkan"] }
+skia-bindings = { version = ">=0.73.0" }
 
 log="0.4"

--- a/skulpin-renderer/Cargo.toml
+++ b/skulpin-renderer/Cargo.toml
@@ -20,12 +20,14 @@ shaper = ["skia-safe/shaper"]
 svg = ["skia-safe/svg"]
 textlayout = ["skia-safe/textlayout"]
 complete = ["skia-safe/textlayout"]
+serde = ["dep:serde"]
 
 [dependencies]
 # rafx does not yet follow semver
 rafx = { version = "=0.0.14", features = ["rafx-vulkan", "framework"] }
 bincode = "1.3.1"
 lazy_static = "1"
+serde = { version = ">=1.0", features = ["derive"], optional = true }
 
 skia-safe = { version = ">=0.73.0", features = ["vulkan"] }
 skia-bindings = { version = ">=0.73.0" }

--- a/skulpin-renderer/src/coordinates.rs
+++ b/skulpin-renderer/src/coordinates.rs
@@ -202,7 +202,7 @@ impl CoordinateSystemHelper {
     /// Use raw pixels for the coordinate system. Top-left is (0, 0), bottom-right is (+X, +Y)
     pub fn use_physical_coordinates(
         &self,
-        canvas: &mut skia_safe::Canvas,
+        canvas: &skia_safe::Canvas,
     ) {
         // For raw physical pixels, no need to do anything
         canvas.reset_matrix();
@@ -213,7 +213,7 @@ impl CoordinateSystemHelper {
     ///   4K displays would probably have a high-dpi factor of 2.0, simulating a 1080p display.
     pub fn use_logical_coordinates(
         &self,
-        canvas: &mut skia_safe::Canvas,
+        canvas: &skia_safe::Canvas,
     ) {
         // To handle hi-dpi displays, we need to compare the logical size of the window with the
         // actual canvas size. Critically, the canvas size won't necessarily be the size of the
@@ -245,7 +245,7 @@ impl CoordinateSystemHelper {
     /// See https://skia.org/user/api/SkMatrix_Reference#SkMatrix_ScaleToFit
     pub fn use_visible_range(
         &self,
-        canvas: &mut skia_safe::Canvas,
+        canvas: &skia_safe::Canvas,
         mut visible_range: skia_safe::Rect,
         scale_to_fit: skia_safe::matrix::ScaleToFit,
     ) -> Result<(), ()> {
@@ -287,7 +287,7 @@ impl CoordinateSystemHelper {
     /// is consistent with the aspect ratio.
     pub fn use_fixed_width(
         &self,
-        canvas: &mut skia_safe::Canvas,
+        canvas: &skia_safe::Canvas,
         center: skia_safe::Point,
         x_half_extents: f32,
     ) -> Result<(), ()> {

--- a/skulpin-renderer/src/renderer.rs
+++ b/skulpin-renderer/src/renderer.rs
@@ -229,7 +229,7 @@ impl Renderer {
 
     /// Call to render a frame. This can block for certain presentation modes. This will rebuild
     /// the swapchain if necessary.
-    pub fn draw<F: FnOnce(&mut skia_safe::Canvas, CoordinateSystemHelper)>(
+    pub fn draw<F: FnOnce(&skia_safe::Canvas, CoordinateSystemHelper)>(
         &mut self,
         window_size: RafxExtents2D,
         scale_factor: f64,
@@ -254,27 +254,23 @@ impl Renderer {
         //
         // Do skia drawing (including the user's callback)
         //
-        let mut canvas = self.skia_surface.as_mut().unwrap().surface.canvas();
+        let canvas = self.skia_surface.as_mut().unwrap().surface.canvas();
 
         let coordinate_system_helper = CoordinateSystemHelper::new(window_size, scale_factor);
 
         match self.coordinate_system {
             CoordinateSystem::None => {}
-            CoordinateSystem::Physical => {
-                coordinate_system_helper.use_physical_coordinates(&mut canvas)
-            }
-            CoordinateSystem::Logical => {
-                coordinate_system_helper.use_logical_coordinates(&mut canvas)
-            }
+            CoordinateSystem::Physical => coordinate_system_helper.use_physical_coordinates(canvas),
+            CoordinateSystem::Logical => coordinate_system_helper.use_logical_coordinates(canvas),
             CoordinateSystem::VisibleRange(range, scale_to_fit) => coordinate_system_helper
-                .use_visible_range(&mut canvas, range, scale_to_fit)
+                .use_visible_range(canvas, range, scale_to_fit)
                 .unwrap(),
             CoordinateSystem::FixedWidth(center, x_half_extents) => coordinate_system_helper
-                .use_fixed_width(&mut canvas, center, x_half_extents)
+                .use_fixed_width(canvas, center, x_half_extents)
                 .unwrap(),
         }
 
-        f(&mut canvas, coordinate_system_helper);
+        f(canvas, coordinate_system_helper);
         self.skia_context.context.flush_and_submit();
 
         //

--- a/skulpin-renderer/src/skia_support.rs
+++ b/skulpin-renderer/src/skia_support.rs
@@ -56,7 +56,7 @@ impl VkSkiaContext {
             )
         };
 
-        let context = skia_safe::gpu::DirectContext::new_vulkan(&backend_context, None).unwrap();
+        let context = skia_safe::gpu::direct_contexts::make_vulkan(&backend_context, None).unwrap();
 
         VkSkiaContext { context }
     }
@@ -92,7 +92,16 @@ pub struct VkSkiaSurface {
 
 impl VkSkiaSurface {
     pub fn get_image_from_skia_texture(texture: &skia_safe::gpu::BackendTexture) -> vk::Image {
-        unsafe { std::mem::transmute(texture.vulkan_image_info().unwrap().image.as_ref().unwrap()) }
+        unsafe {
+            std::mem::transmute(
+                texture
+                    .vulkan_image_info()
+                    .unwrap()
+                    .image()
+                    .as_ref()
+                    .unwrap(),
+            )
+        }
     }
 
     pub fn new(
@@ -115,20 +124,23 @@ impl VkSkiaSurface {
             color_space,
         );
 
-        let mut surface = skia_safe::Surface::new_render_target(
+        let mut surface = skia_safe::gpu::surfaces::render_target(
             &mut context.context,
-            skia_safe::Budgeted::Yes,
+            skia_safe::gpu::Budgeted::Yes,
             &image_info,
             None,
             skia_safe::gpu::SurfaceOrigin::TopLeft,
             None,
             false,
+            None,
         )
         .unwrap();
 
-        let texture = surface
-            .get_backend_texture(skia_safe::surface::BackendHandleAccess::FlushRead)
-            .unwrap();
+        let texture = skia_safe::gpu::surfaces::get_backend_texture(
+            &mut surface,
+            skia_safe::surface::BackendHandleAccess::FlushRead,
+        )
+        .unwrap();
         let image = Self::get_image_from_skia_texture(&texture);
 
         // According to docs, kN32_SkColorType can only be kRGBA_8888_SkColorType or


### PR DESCRIPTION
Hi,

As the title says, this brings support for newer skia-safe versions, with the minimum being 0.73. I tested with this version and the latest 0.78.2. I ran through all the examples. No warnings or errors, but only tested on Windows.

This would be pretty straight-forward, but it introduces a breaking change, thanks to https://github.com/rust-skia/rust-skia/pull/816 , which is released starting with [v0.67.0](https://github.com/rust-skia/rust-skia/releases/tag/0.67.0).

The `Canvas` instance returned by `*SkiaSurface::canvas()` (and others) is no longer mutable, so, as far as I can tell, the signature of the callback passed to `Renderer::draw()` needed to change also so that the `Canvas` reference is no longer mutable.

```diff
-- pub fn draw<F: FnOnce(&mut skia_safe::Canvas, CoordinateSystemHelper)>(
++ pub fn draw<F: FnOnce(&skia_safe::Canvas, CoordinateSystemHelper)>(
```

Which I imagine will break probably every downstream usage of `Renderer`. Maybe there's some other clever way to fix this so it doesn't break existing `Renderer::draw()` callbacks, but from what I understand this could be a "bad idea."

This also makes the skia-safe version ">=" again so this crate can be used alongside others with a higher version dependency (subject to future breaking changes in their crate, of course). I picked v0.73.0 as the minimum since that was the last version with a breaking change which affected `skulpin`.

No worries if you're not interested, just close it...  I was updating my version of `skia-canvas` (JS interface to `skia-safe`) which uses `skulpin` for one of its features, and it was much easier to fix than replace and cooler than removing the feature. :)

Cheers,
-Max
